### PR TITLE
Make `belongs_to :class` optional (comply with Rails 5)

### DIFF
--- a/lib/notifications/model.rb
+++ b/lib/notifications/model.rb
@@ -8,9 +8,9 @@ module Notifications
       belongs_to :actor, class_name: Notifications.config.user_class
       belongs_to :user, class_name: Notifications.config.user_class
 
-      belongs_to :target, polymorphic: true
-      belongs_to :second_target, polymorphic: true
-      belongs_to :third_target, polymorphic: true
+      belongs_to :target, polymorphic: true, optional: true
+      belongs_to :second_target, polymorphic: true, optional: true
+      belongs_to :third_target, polymorphic: true, optional: true
 
       scope :unread, -> { where(read_at: nil) }
     end


### PR DESCRIPTION
`belongs_to` will now trigger a validation **error** by default if the association is not present (https://github.com/rails/rails/pull/18937).

This breaks the possibility of creating a Notification without targets, such as:

```ruby
Notification.create(notify_type: 'follow', actor: self, user: user)
```

This can be fixed either by adding `optional: true` in the Model (this PR), or changing `Rails.application.config.active_record.belongs_to_required_by_default` to false in dev's apps.